### PR TITLE
Fix Table size check

### DIFF
--- a/src/bsearch.mts
+++ b/src/bsearch.mts
@@ -43,7 +43,7 @@ export class Table<K extends unknown, T extends readonly [K, ...unknown[]]>
 
     // check pre-conditions
     check(
-      table.length > 1,
+      table.length > 0,
       ValueError,
       "The table must contain at least one element"
     );

--- a/test/bsearch.spec.mts
+++ b/test/bsearch.spec.mts
@@ -18,6 +18,13 @@ describe("Table", function () {
     assert.notEqual(table.toArray(), table.table);
   });
 
+  it("can be created from a single tuple", function () {
+    const data: [string, number][] = [["A", 1]];
+
+    const table = new Table(data);
+    assert.deepEqual(table.toArray(), data);
+  });
+
   it("expects ordered data", function () {
     const data: [string, number][] = [
       ["A", 1],


### PR DESCRIPTION
## Summary
- allow creating Table with a single row
- add regression test for single-tuple tables

## Testing
- `yarn compile-in-container` *(fails: Error when performing the request)*
- `npm run test-in-container` *(fails: `env: ‘mocha’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684412395a748330bcac9dc4ff52bf95