### PR TITLE
Rename CLI entry and drop unused main

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ for multiple wallets.  Accounting requirements forced several design changes:
 - tokens stored on different blockchains now map to logical **crypto assets** so
   that a single asset (for example USDC) can be reported regardless of the
   chain it resides on
-- the library gained a command‑line entry point at `cli/blockchain-cli.mts` for
+- the library gained a command‑line entry point at `cli/report-cli.mts` (formerly
+  `blockchain-cli.mts`) for
   processing wallets and generating reports
 
 Today Wallet Valuator is both a library and a CLI application focused on
@@ -71,6 +72,17 @@ sh$ npm run lint
 sh$ npm run shell
 node@2b9634cf5c20:~$ exec npm run lint-in-container
 ```
+
+## CLI Usage
+
+Once the project is compiled you can generate a report from a configuration file
+inside the container:
+
+```sh
+node build/cli/report-cli.mjs --config mywallet.json
+```
+
+The resulting text can be copied directly into your yearly French tax return.
 
 ## Important Notice
 

--- a/cli/report-cli.mts
+++ b/cli/report-cli.mts
@@ -1,12 +1,15 @@
 import { Command } from "commander";
-import { processAddresses } from "../src/lib/cli/addressprocessor.mjs";
+import { processAddresses } from "../src/lib/cli/report.mjs";
 
 // Initialize commander
 const program = new Command();
 
+/**
+ * Generate an accounting report from a configuration file.
+ */
 program
-  .name("blockchain-cli")
-  .description("Command-line tool to display blockchain addresses")
+  .name("report-cli")
+  .description("Generate a text report for income tax declarations")
   .showHelpAfterError()
   .version("1.1.0")
   .option("-c, --config <config.json>", "JSON configuration")

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build-container": "sudo docker build --tag \"${npm_package_config_container_tag}\" - < DOCKERFILE",
     "shell-in-container": "env $(echo LOCAL_ENV=1; cat .env) /bin/bash",
-    "start-in-container": "env $(echo LOCAL_ENV=1; cat .env) node -r source-map-support/register build/src/main.mjs",
+    "start-in-container": "env $(echo LOCAL_ENV=1; cat .env) node -r source-map-support/register build/cli/report-cli.mjs",
     "test-in-container": "env $(echo LOCAL_ENV=1; cat .env) mocha 'build/test/**/*.mjs'",
     "lint-in-container": "eslint --fix src test",
     "compile-in-container": "tsc",

--- a/src/lib/cli/report.mts
+++ b/src/lib/cli/report.mts
@@ -1,3 +1,9 @@
+/**
+ * Backend logic for generating a wallet valuation report.
+ *
+ * The report consolidates transfers across multiple addresses and
+ * converts their value in EUR for income tax reporting.
+ */
 import { readFile } from "node:fs/promises";
 
 import { Swarm } from "../../../src/swarm.mjs";

--- a/src/main.mts
+++ b/src/main.mts
@@ -1,5 +1,0 @@
-console.log(greetings());
-
-export function greetings() {
-  return "Hello";
-}

--- a/test/main.spec.mts
+++ b/test/main.spec.mts
@@ -1,8 +1,0 @@
-import { assert } from "chai";
-import * as main from "../src/main.mjs";
-
-describe("Suite", () => {
-  it("works", () => {
-    assert.equal("Hello", main.greetings());
-  });
-});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -110,7 +110,7 @@
     "src/geckocoin.mts",
     "src/instancecache.mts",
     "src/ledger.mts",
-    "src/lib/cli/addressprocessor.mts",
+    "src/lib/cli/report.mts",
     "src/lib/cli/blockexplorer.mts",
     "src/lib/cli/loader.mts",
     "src/metadata.mts",
@@ -161,12 +161,9 @@
     "examples/find-address.mts",
     "examples/report.mts",
 
-    "cli/blockchain-cli.mts",
+    "cli/report-cli.mts",
     "cli/blockexplorer-cli.mts",
-    "cli/load.mts",
-
-    "src/main.mts",
-    "test/main.spec.mts"
+    "cli/load.mts"
   ],
   "watchOptions": {
     "watchFile": "dynamicprioritypolling",


### PR DESCRIPTION
## Summary
- remove old main program
- rename the main CLI to `report-cli`
- rename its backend module to `report.mts`
- update scripts, tsconfig and docs
- document CLI usage in README

## Testing
- `npm run lint-in-container` *(fails: many lint errors)*
- `GNOSISSCAN_API_KEY=dummy COINGECKO_API_KEY=dummy CACHE_PATH=/tmp/cache npm run test-in-container` *(fails: network errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ab73096cc8330a95cca90a1a8a73d