### PR TITLE
 ✅ Add calendar validation to parseDate

### DIFF
--- a/src/date.mts
+++ b/src/date.mts
@@ -62,11 +62,24 @@ export function parseDate(format: string | RegExp, date: string) {
   }
 
   if (/^\d+$/.test(`${year}${month}${day}`)) {
-    return new Date(
-      parseInt(year, 10),
-      parseInt(month, 10) - 1,
-      parseInt(day, 10)
-    );
+    const yearNumber = parseInt(year, 10);
+    const monthNumber = parseInt(month, 10);
+    const dayNumber = parseInt(day, 10);
+
+    const parsedDate = new Date(yearNumber, monthNumber - 1, dayNumber);
+
+    const isValidDate =
+      parsedDate.getUTCFullYear() === yearNumber &&
+      parsedDate.getUTCMonth() + 1 === monthNumber &&
+      parsedDate.getUTCDate() === dayNumber;
+
+    if (!isValidDate) {
+      throw new ValueError(
+        `${date} is not a valid calendar date`
+      );
+    }
+
+    return parsedDate;
   }
 
   throw new ValueError(

--- a/test/date.spec.mts
+++ b/test/date.spec.mts
@@ -91,6 +91,11 @@ describe("Date utilities", () => {
         [ "12--2022", /(?<month>\d\d)--(?<year>\d\d\d\d)/, ValueError],
         [ "24--12--202Z", /(?<day>..)--(?<month>..)--(?<year>....)/, ValueError ],
         [ "--12--202Z", /(?<day>.*)--(?<month>..)--(?<year>....)/, ValueError ],
+        [ "2022-13-01", "YYYY-MM-DD", ValueError ],
+        [ "2022-12-32", "YYYY-MM-DD", ValueError ],
+        [ "2022-02-30", "YYYY-MM-DD", ValueError ],
+        [ "2023-02-29", "YYYY-MM-DD", ValueError ],
+        [ "2024-02-30", "YYYY-MM-DD", ValueError ],
       ] as const;
 
       for (const [input, format, error] of testcases) {


### PR DESCRIPTION
## Summary
- add a calendar validity check to `parseDate` so invalid dates are rejected
- raise a clear `ValueError` when the parsed date does not exist
- extend the unit test suite to cover invalid day and month combinations

## Testing
- `time npx tsc --pretty false`
- `GNOSISSCAN_API_KEY=dummy COINGECKO_API_KEY=dummy npx mocha 'build/test/date.spec.mjs'`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691597502a34833086c4da6f496a127e)