### PR TITLE
fix: type Curve chain name maps

### DIFF
--- a/src/services/curve/curveapi.mts
+++ b/src/services/curve/curveapi.mts
@@ -84,21 +84,20 @@ export type CurveOHLC = {
 // We provide the ToCurveChainName and FromCurveChainName utilities to perform
 // the conversion transparently:
 
-export const ToCurveChainName: Record<string, string> = {
-  // ISSUE #100 string | undefined
-  // @ts-expect-error The null-prototype literal object syntax is not supported by TypeScript
-  __proto__: null,
+const createChainNameMap = (
+  entries: Record<string, string>,
+): Record<string, string | undefined> =>
+  Object.freeze(
+    Object.assign(Object.create(null) as Record<string, string | undefined>, entries),
+  );
 
+export const ToCurveChainName = createChainNameMap({
   gnosis: "xdai",
-} as const;
+});
 
-export const FromCurveChainName: Record<string, string> = {
-  // ISSUE #100 string | undefined
-  // @ts-expect-error The null-prototype literal object syntax is not supported by TypeScript
-  __proto__: null,
-
+export const FromCurveChainName = createChainNameMap({
   xdai: "gnosis",
-} as const;
+});
 
 /**
  * Converts a JavaScript Date object to Unix timestamp (seconds since epoch) as expected by the Curve API.


### PR DESCRIPTION
## Summary

- type `ToCurveChainName` and `FromCurveChainName` as `Record<string, string | undefined>`
- replace the `__proto__` object-literal workaround and `@ts-expect-error` comments with a typed null-prototype map helper
- preserve the existing Curve chain-name translations (`gnosis` <-> `xdai`)

Closes #100.

## Verification

- `npm run compile`
- `node` import smoke check against `build/src/services/curve/curveapi.mjs` verified:
  - `ToCurveChainName.gnosis === "xdai"`
  - `FromCurveChainName.xdai === "gnosis"`
  - unknown chains return `undefined`
  - the exported maps keep a null prototype

Notes:

- `npm test -- --grep CurveAPI` currently has one unrelated floating-point fixture mismatch (`1.0397308967364007` vs `1.0397308967364005`) in `getPrice()`; the other CurveAPI checks in that grep pass.
- `npm run lint` reports pre-existing project-wide lint errors outside this focused change; no unrelated files are included in this PR.
